### PR TITLE
Test query

### DIFF
--- a/src/HospitalEpidemiology/Model/PatientRoomStay.cs
+++ b/src/HospitalEpidemiology/Model/PatientRoomStay.cs
@@ -8,7 +8,12 @@ namespace HospitalEpidemiology.Model;
 public class PatientRoomStay
 {
     int id;
+
     public required Patient Patient { get; set; }
+    public int PatientId { get; set; }
+
     public required Room Room { get; set; }
+    public int RoomId { get; set; }
+
     public required NpgsqlRange<DateTime> Stay { get; set; }
 }

--- a/src/HospitalEpidemiology/Program.cs
+++ b/src/HospitalEpidemiology/Program.cs
@@ -6,10 +6,50 @@ using NpgsqlTypes;
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContextPool<HospitalEpidemiologyDb>(
     opt => opt.UseNpgsql(builder.Configuration.GetConnectionString("HospitalEpidemiology"))
+        .LogTo(Console.WriteLine, LogLevel.Information)
+        .EnableSensitiveDataLogging()
         .UseSnakeCaseNamingConvention()
         .EnableThreadSafetyChecks(false));
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 var app = builder.Build();
+
+var scope = app.Services.CreateScope();
+var context = scope.ServiceProvider.GetService<HospitalEpidemiologyDb>();
+
+var indexPatientId = 8;
+var minimumCumulativeContactDuration = TimeSpan.FromMinutes(90);
+var riskRange = new NpgsqlRange<DateTime>(
+    new(2020, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+    new(2020, 1, 3, 12, 0, 0, DateTimeKind.Utc));
+
+var query =
+    from overlappingPatients in
+        // Start with the index patient's stays, filtering out any which are completely outside the risk range
+        from indexPatientStay in context.PatientRoomStays
+        where indexPatientStay.PatientId == indexPatientId
+              && indexPatientStay.Stay.Overlaps(riskRange)
+        // Join with other patient stays that have the same room and overlapping stays
+        from patientStay in context.PatientRoomStays
+        where patientStay.PatientId != indexPatientId
+              && patientStay.RoomId == indexPatientStay.RoomId
+              && patientStay.Stay.Overlaps(indexPatientStay.Stay)
+        // Group by the patient, intersecting all their stays with the risk range, projecting the intersected stays
+        // to the TimeSpan duration, and aggregating that duration
+        group patientStay.Stay by patientStay.PatientId
+        into patientStayGroup
+        select new
+        {
+            PatientId = patientStayGroup.Key,
+            AggregateOverlapTime = EF.Functions.Sum(patientStayGroup.Select(s => s.Intersect(riskRange))
+                .Select(s => s.UpperBound - s.LowerBound))
+        }
+    // From the above subquery, filter out patients which which didn't overlap for enough tmie
+    where overlappingPatients.AggregateOverlapTime > minimumCumulativeContactDuration
+    select overlappingPatients;
+
+_ = query.ToArray();
+
+Environment.Exit(0);
 
 app.MapGet("/roomContacts", async ([FromQuery] int indexPatientId, [FromQuery] DateTime? riskFromInclusive, [FromQuery] DateTime? riskToExclusive, [FromQuery] TimeSpan minimumCumulativeContactDuration, HospitalEpidemiologyDb db) =>
 {


### PR DESCRIPTION
Hey @Brar, I think this is more or less what you're looking for:

```c#
from overlappingPatients in
    // Start with the index patient's stays, filtering out any which are completely outside the risk range
    from indexPatientStay in context.PatientRoomStays
    where indexPatientStay.PatientId == indexPatientId
          && indexPatientStay.Stay.Overlaps(riskRange)
    // Join with other patient stays that have the same room and overlapping stays
    from patientStay in context.PatientRoomStays
    where patientStay.PatientId != indexPatientId
          && patientStay.RoomId == indexPatientStay.RoomId
          && patientStay.Stay.Overlaps(indexPatientStay.Stay)
    // Group by the patient, intersecting all their stays with the risk range, projecting the intersected stays
    // to the TimeSpan duration, and aggregating that duration
    group patientStay.Stay by patientStay.PatientId
    into patientStayGroup
    select new
    {
        PatientId = patientStayGroup.Key,
        AggregateOverlapTime = EF.Functions.Sum(patientStayGroup.Select(s => s.Intersect(riskRange))
            .Select(s => s.UpperBound - s.LowerBound))
    }
// From the above subquery, filter out patients which which didn't overlap for enough tmie
where overlappingPatients.AggregateOverlapTime > minimumCumulativeContactDuration
select overlappingPatients;
```

SQL:

```sql
SELECT p0.patient_id AS "PatientId", sum(upper(p0.stay * @__riskRange_1) - lower(p0.stay * @__riskRange_1)) AS "AggregateOverlapTime"
FROM patient_room_stays AS p
CROSS JOIN patient_room_stays AS p0
WHERE p.patient_id = @__indexPatientId_0 AND p.stay && @__riskRange_1 AND p0.patient_id <> @__indexPatientId_0 AND p0.room_id = p.room_id AND p0.stay && p.stay
GROUP BY p0.patient_id
HAVING sum(upper(p0.stay * @__riskRange_1) - lower(p0.stay * @__riskRange_1)) > @__minimumCumulativeContactDuration_3
```

I haven't tested this or anything, but it should work. This:
1. Selects the index patients stays, filtering out any which don't overlap with the risk range
2. (Self-joins) with stays of all other patients, keeping only those which overlap with the index patient's stays (same room, overlapping stay)
3. Group by the patient ID, intersecting their stays with the risk range, and then aggregating them all to their total, cumulative TimeSpan
4. Filter out any patients whose cumulative overlapping stay is below the minimum threshold

Some nice PG-specific translations are at play here, including EF.Functions.Sum over TimeSpan (which I added recently), overlap, range upper/lower bound. Good to see this all working together.

Tell me what you think!